### PR TITLE
Ros2 fixes

### DIFF
--- a/ros/docs/ros.md
+++ b/ros/docs/ros.md
@@ -246,6 +246,7 @@ Subscribe to the named topic of the named type. Each time a new message
 is received the provided callback is called. For available options see
 [https://robotwebtools.github.io/rclnodejs/docs/0.22.3/Node.html#createSubscription][1].
 The default `options.qos.reliability` is best-effort.
+options object can contain: "throttleMs": throttle-in-milliseconds.
 
 ##### Parameters
 

--- a/ros/docs/ros.md
+++ b/ros/docs/ros.md
@@ -238,7 +238,7 @@ advertise the topic if not yet advertised.
 *   `topic` &#x20;
 *   `type` &#x20;
 *   `message` &#x20;
-*   `latching`   (optional, default `true`)
+*   `latching`   (optional, default `false`)
 
 ### subscribe
 

--- a/ros/ros/ros2.js
+++ b/ros/ros/ros2.js
@@ -102,7 +102,11 @@ class ROS2 {
     this.requireInit();
     let topics = this.node.getTopicNamesAndTypes();
     const ros2Type = toROS2Type(type);
-    ros2Type && (topics = topics.filter(topic => topic.types.includes(ros2Type)));
+    ros2Type && 
+    (topics = topics
+      .filter(topic => topic.types.includes(ros2Type))
+      .map(topic => ({name: topic.name, type: ros2Type}))
+    );
     return topics;
   }
 

--- a/ros/ros/ros2.js
+++ b/ros/ros/ros2.js
@@ -209,12 +209,13 @@ class ROS2 {
 
   /** Unsubscribe from topic */
   unsubscribe(topic) {
-    if (!this.subscriptions[topic]) {
+    const sub = this.subscriptions[topic];
+    if (!sub) {
       console.warn(`cannot unsubscribe from ${topic}, subscription not found`);
       return;
     }
-    this._destroySubscriber(this.subscriptions[topic].volatileSubscriber);
-    this._destroySubscriber(this.subscriptions[topic].latchingSubscriber);
+    this._destroySubscriber(sub.volatileSubscriber);
+    this._destroySubscriber(sub.latchingSubscriber);
     delete this.subscriptions[topic];
   }
 

--- a/ros/ros/ros2.js
+++ b/ros/ros/ros2.js
@@ -152,6 +152,10 @@ class ROS2 {
     this.requireInit();
     let firstLatchedMessage;
     const ros2Type = toROS2Type(type);
+    const _onMessage = options?.throttleMs ?
+      _.throttle(onMessage, options.throttleMs, { trailing: false }) :
+      onMessage;
+
     const _destroyLatchingSub = () => {
       const subs = this.subscriptions[topic];
       if (subs?.latching){
@@ -167,7 +171,7 @@ class ROS2 {
       ros2Type, topic, {latchingQos, ...options}, (msg) => {
         _destroyLatchingSub();
         firstLatchedMessage = msg;
-        onMessage(msg);
+        _onMessage(msg);
       }
     );
 
@@ -182,7 +186,7 @@ class ROS2 {
           }
           firstLatchedMessage = undefined;          
         }
-        onMessage(msg);
+        _onMessage(msg);
       }
     );  
 

--- a/ros/ros/ros2.js
+++ b/ros/ros/ros2.js
@@ -208,10 +208,8 @@ class ROS2 {
           console.warn(`cannot shutdown ${topic}, subscription not found`);
           return;
         }
-        console.log('Removing listener for', topic);
         sub.emitter.off('message', throttledCallback);
         if (sub.emitter.listenerCount('message') == 0) {
-          console.log('No more listeners for', topic);
           this.unsubscribe(topic);
         }
       }
@@ -225,7 +223,6 @@ class ROS2 {
       console.warn(`cannot unsubscribe from ${topic}, subscription not found`);
       return;
     }
-    console.log('Unsubscribing from', topic);
     sub.emitter.removeAllListeners('message');
     this._destroySubscriber(sub.volatileSubscriber);
     this._destroySubscriber(sub.latchingSubscriber);

--- a/ros/ros/ros2.js
+++ b/ros/ros/ros2.js
@@ -168,35 +168,35 @@ class ROS2 {
       _.throttle(onMessage, options.throttleMs) :
       onMessage;
 
-    // we create two subscriptions, one for latched messages and one for volatile (new) messages
-    // after receiving the first message we destroy the latched subscription and only keep the volatile one
-    // we need to do this because of qos incompatibilities between volatile/latching pubs and subs
-    // we can't have a single subscription that can handle both, and user may not be in control of the publisher
-    // see https://docs.ros.org/en/rolling/Concepts/Intermediate/About-Quality-of-Service-Settings.html#qos-compatibilities
-    const latchingSub = this.node.createSubscription(
-      ros2Type, topic, {qos: latchingQos, ...options}, (msg) => {
-        this._destroySubscriber(latchingSub);
-        firstLatchedMessage = msg;
-        this.emitter.emit(topic, msg);
-      }
-    );
-
-    const volatileSub = this.node.createSubscription(
-      ros2Type, topic, {qos: volatileQos, ...options}, (msg) => {
-        this._destroySubscriber(latchingSub);
-        if (firstLatchedMessage) {
-          if (_.isEqual(firstLatchedMessage, msg)) {
-            firstLatchedMessage = undefined;
-            // avoids duplicating first message
-            return;
-          }
-          firstLatchedMessage = undefined;          
-        }
-        this.emitter.emit(topic, msg);
-      }
-    );  
-
     if (!this.subscriptions[topic]) {
+      // we create two subscriptions, one for latched messages and one for volatile (new) messages
+      // after receiving the first message we destroy the latched subscription and only keep the volatile one
+      // we need to do this because of qos incompatibilities between volatile/latching pubs and subs
+      // we can't have a single subscription that can handle both, and user may not be in control of the publisher
+      // see https://docs.ros.org/en/rolling/Concepts/Intermediate/About-Quality-of-Service-Settings.html#qos-compatibilities
+      const latchingSub = this.node.createSubscription(
+        ros2Type, topic, {qos: latchingQos, ...options}, (msg) => {
+          this._destroySubscriber(latchingSub);
+          firstLatchedMessage = msg;
+          this.emitter.emit(topic, msg);
+        }
+      );
+
+      const volatileSub = this.node.createSubscription(
+        ros2Type, topic, {qos: volatileQos, ...options}, (msg) => {
+          this._destroySubscriber(latchingSub);
+          if (firstLatchedMessage) {
+            if (_.isEqual(firstLatchedMessage, msg)) {
+              firstLatchedMessage = undefined;
+              // avoids duplicating first message
+              return;
+            }
+            firstLatchedMessage = undefined;          
+          }
+          this.emitter.emit(topic, msg);
+        }
+      );  
+
       this.subscriptions[topic] = {
         volatileSubscriber: volatileSub,
         latchingSubscriber: latchingSub,

--- a/ros/test/ros.test.js
+++ b/ros/test/ros.test.js
@@ -76,6 +76,42 @@ test('loads', () => {
       }, 500);
     });
 
+    test('can handle multiple subscribers on same topic', (done) => {
+      const topic = '/utils_ros/testmultisubscribers';
+      const type = version == 1 ? 'std_msgs/String' : 'std_msgs/msg/String';
+      let receivedMsgs = 0;
+
+      const wrapUp = () => {
+        receivedMsgs++;
+        if(receivedMsgs == 3) {
+          done();
+        }
+      }
+
+      const sub1 = ros.subscribe(topic, type, (msg) => {
+        console.log('received message on sub1', msg);
+        expect(msg.data).toEqual('multisubscribers');
+        sub1.shutdown();
+        wrapUp();
+      });
+
+      const sub2 = ros.subscribe(topic, type, (msg) => {
+        console.log('received message on sub2', msg);
+        expect(msg.data).toEqual('multisubscribers');
+        sub2.shutdown();
+        wrapUp();
+      });
+
+      const sub3 = ros.subscribe(topic, type, (msg) => {
+        console.log('received message on sub3', msg);
+        expect(msg.data).toEqual('multisubscribers');
+        sub3.shutdown();
+        wrapUp();
+      });
+
+      ros.publish(topic, type, {data: 'multisubscribers'}, false);
+    });
+
     test('can publish messages with headers', () => {
       const topic = '/test_diag';
       const type = 'diagnostic_msgs/DiagnosticArray';

--- a/ros/test/ros.test.js
+++ b/ros/test/ros.test.js
@@ -32,6 +32,8 @@ test('loads', () => {
     });
 
     test('gets topics', async () => {
+      const topic = '/utils_ros/testtopic';
+      ros.publish(topic, type, {data: String(Date.now())});
       const list = await ros.getTopics();
       expect(list.length > 0).toBeTruthy();
     });
@@ -46,15 +48,14 @@ test('loads', () => {
         first && done();
         first = false;
       });
-      ros.publish(topic, type, {data: String(Date.now())}, false);
+      ros.publish(topic, type, {data: String(Date.now())});
     });
 
     test('can receive latched messages', (done) => {
       const topic = '/utils_ros/testlatchedmessages';
-      const type = version == 1 ? 'std_msgs/String' : 'std_msgs/msg/String';
       let receivedMsgs = 0;
 
-      ros.publish(topic, type, {data: 'latched'});
+      ros.publish(topic, type, {data: 'latched'}, true);
       // sleep for a bit and subscribe later to ensure message is latched
       setTimeout(() => {
         const sub = ros.subscribe(topic, type, (msg) => {
@@ -73,42 +74,6 @@ test('loads', () => {
           ros.publish(topic, type, {data: 'volatile'}, false);
         }, 500);
       }, 500);
-    });
-
-    test('can handle multiple subscribers on same topic', (done) => {
-      const topic = '/utils_ros/testmultisubscribers';
-      const type = version == 1 ? 'std_msgs/String' : 'std_msgs/msg/String';
-      let receivedMsgs = 0;
-
-      const wrapUp = () => {
-        receivedMsgs++;
-        if(receivedMsgs == 3) {
-          done();
-        }
-      }
-      
-      const sub1 = ros.subscribe(topic, type, (msg) => {
-        console.log('received message on sub1', msg);
-        expect(msg.data).toEqual('multisubscribers');
-        sub1.shutdown();
-        wrapUp();
-      });
-
-      const sub2 = ros.subscribe(topic, type, (msg) => {
-        console.log('received message on sub2', msg);
-        expect(msg.data).toEqual('multisubscribers');
-        sub2.shutdown();
-        wrapUp();
-      });
-
-      const sub3 = ros.subscribe(topic, type, (msg) => {
-        console.log('received message on sub3', msg);
-        expect(msg.data).toEqual('multisubscribers');
-        sub3.shutdown();
-        wrapUp();
-      });
-
-      ros.publish(topic, type, {data: 'multisubscribers'}, false);
     });
 
     test('can publish messages with headers', () => {


### PR DESCRIPTION
- adds throttling option to ROS2 subscribers
  - needs test 
- adds latching support to ROS2 pub/subs
- getTopicsWithTypes returns {name: topicName, type: topicType } (same fields as ROS1 response
- allows multiple subscribers for same ROS2 topic, handling independent subscribers shutdown

closes #3 
closes #4 
closes #5 
closes #7 