### PR TITLE
utils-ros@0.10: use rclnodejs1.5.2 when possible

### DIFF
--- a/ros/README.md
+++ b/ros/README.md
@@ -27,8 +27,8 @@ const demo = async (version) => {
   });
 };
 
-demo(1);
-demo(2);
+demo(1); // ROS 1
+demo(2); // ROS 2
 ```
 
 ## Running Tests
@@ -44,4 +44,5 @@ npm test
 
 # Changelog
 
+- v0.10: using rclnodejs@1.5.2 with pre-built binaries if possible (Humble+)
 - v0.9: added support for ROS parameters

--- a/ros/package-lock.json
+++ b/ros/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@transitive-sdk/utils-ros",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@transitive-sdk/utils-ros",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/ros/package.json
+++ b/ros/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transitive-sdk/utils-ros",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Utils for using ROS with Transitive",
   "homepage": "https://transitiverobotics.com",
   "repository": {

--- a/ros/postinstall.sh
+++ b/ros/postinstall.sh
@@ -8,8 +8,13 @@
 NPM="$NODE $npm_execpath"
 
 if [[ $ROS_VERSION == 2 ]]; then
-  echo 'Found ROS2, installing rclnodejs'
-  $NPM i --no-save rclnodejs@0.27.0
+  if [[ $ROS_DISTRO == "galactic" ]]; then
+    echo 'Found ROS2 galactic, installing and building rclnodejs@0.27'
+    $NPM i --no-save rclnodejs@0.27.0
+  else
+    echo 'Found ROS2, installing rclnodejs@1.5.2 (pre-built)'
+    $NPM i --no-save rclnodejs@1.5.2
+  fi
 else
   echo ROS2 not found
 fi


### PR DESCRIPTION
- i.e., anywhere but on ROS galactic